### PR TITLE
2d test file uploads

### DIFF
--- a/breadboard_row_script.cs
+++ b/breadboard_row_script.cs
@@ -1,0 +1,107 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Xml.Schema;
+using Unity.PlasticSCM.Editor.WebApi;
+using Unity.VisualScripting;
+using UnityEngine;
+
+public class breaboard_row_script : MonoBehaviour
+{
+    public float rowVoltage=0 ;
+    public float outResistance ;
+    float voltageDrop ;
+    float previousRow = 0;
+    bool inTrigger = false;
+
+
+     void Update()
+    {
+        if (inTrigger)
+        {
+            readSourceBar();
+        }
+    }
+    private void readSourceBar()
+    {
+
+        //activate RecalculateCurrent fucntion using the newly calculated total resistance
+        float totalResistance = transform.parent.Find("source bar").GetComponent<source_bar_script>().totalResistance;
+        transform.parent.Find("source bar").GetComponent<source_bar_script>().RecalculateCurrent(totalResistance);
+
+        // save calculated current
+        float current = transform.parent.GetComponentInChildren<source_bar_script>().current;
+
+        //calculate voltage drop
+        voltageDrop = outResistance * current;
+        string vdrop = "vdrop = " + outResistance + " * " + current;
+        Debug.Log(vdrop + " = " + voltageDrop);
+
+        
+        
+
+        
+    }
+    public void OnTriggerEnter2D(Collider2D collision)
+    {
+        inTrigger = true;
+
+        // see if collidng object is labeld as an output, ie is a wire
+        if (collision.gameObject.CompareTag("output"))
+        {
+            Debug.Log(gameObject.name + "is touching an output");
+
+            // check if touching end 2 or end 1
+            if (collision.gameObject.name == "wire end 2")
+            {
+                rowVoltage = collision.gameObject.GetComponent<wire_end2_script>().outputVoltage;
+            }
+            if (collision.gameObject.name == "wire end 1")
+            {
+                rowVoltage = collision.gameObject.GetComponent<wire_end1_script>().outputVoltage;
+            }
+            gameObject.tag = "charged board row";
+            Debug.Log(gameObject.transform.name + "is now charged to " + rowVoltage + " volts");
+        }
+        // check if object is labeled as a resistor output
+        if (collision.gameObject.CompareTag("resistor output"))
+        {
+            Debug.Log(gameObject.name + "is touching an resistor");
+
+            // detect  what resitance of the resistor is 
+            if (collision.gameObject.name == "wire end 1")
+            {
+                 outResistance = collision.gameObject.GetComponent<wire_end1_script>().resistance;
+            }
+            else if (collision.gameObject.name == "wire end 2")
+            {
+                outResistance = collision.gameObject.GetComponent<wire_end2_script>().resistance;
+
+            }
+            // add component resistance to total resistance acknowldged by circuit
+            transform.parent.Find("source bar").GetComponent<source_bar_script>().totalResistance = +outResistance;
+
+            // calcuate current node voltage through votlage drop and last node
+            float previousRow = collision.gameObject.transform.parent.GetComponentInChildren<wire_end1_script>().contactVoltage;
+            rowVoltage = previousRow - voltageDrop;
+            string rowVolt = "rowVolt = " + previousRow + " - " + voltageDrop;
+            Debug.Log(rowVolt);
+
+            //consider row charged
+            gameObject.tag = "charged board row";
+            Debug.Log(gameObject.transform.name + "is now charged to " + rowVoltage + " volts");
+            Debug.Log("Previous node had " + previousRow);
+            Debug.Log("total resistance is : " + transform.parent.Find("source bar").GetComponent<source_bar_script>().totalResistance);
+
+        }
+
+    }
+    public void OnTriggerExit2D(Collider2D collision)
+    {
+        inTrigger = false;
+        rowVoltage = 0;
+    }
+    
+
+}
+
+

--- a/resistor_logic_script.cs
+++ b/resistor_logic_script.cs
@@ -1,0 +1,74 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class resistor_logc_script : MonoBehaviour
+{
+    public wire_end1_script wireEnd1Script;
+    public wire_end2_script wireEnd2Script;
+    void Update()
+    {
+        wire_logic();
+    }
+
+    bool wire1SourceTouch = false;
+    bool wire2SourceTouch = false;
+    bool wire1ChargeTouch = false;
+    bool wire2ChargeTouch = false;
+
+
+    void wire_logic()
+    {
+        // check if either end is touching a source or a charge
+        wireEnd1Script = GetComponentInChildren<wire_end1_script>();
+        wire1SourceTouch = wireEnd1Script.sourceTouch;
+        wireEnd2Script = GetComponentInChildren<wire_end2_script>();
+        wire2SourceTouch = wireEnd2Script.sourceTouch;
+
+        wireEnd1Script = GetComponentInChildren<wire_end1_script>();
+        wire1ChargeTouch = wireEnd1Script.chargeTouch;
+        wireEnd2Script = GetComponentInChildren<wire_end2_script>();
+        wire2ChargeTouch = wireEnd2Script.chargeTouch;
+
+
+        float resistance =10;
+
+        // if 1 is touching a source, then 2 is sending the source i.e. is output
+
+        if (wire1SourceTouch == true)
+        {
+            Transform wireEnd2Transform = transform.Find("wire end 2");
+            wireEnd2Transform.tag = "resistor output";
+            wireEnd2Script.resistance =resistance;
+            Debug.Log("wire end 2 now resitstor with " + resistance);
+        }
+        //vice versa
+        else if (wire2SourceTouch == true)
+        {
+            Transform wireEnd1Transform = transform.Find("wire end 1");
+            wireEnd1Transform.tag = "resistor output";
+            wireEnd1Script.resistance = resistance;
+            Debug.Log("wire end 1 now resistor with " +resistance);
+        }
+
+        // if wire 1 touches active non source bar, carry signal to be output of 2
+        else if (wire1ChargeTouch == true)
+        {
+            Transform wireEnd2Transform = transform.Find("wire end 2");
+            wireEnd2Script.resistance = resistance;
+            wireEnd2Transform.tag = "resistor output";
+            Debug.Log("wire end 2 is now resistor with " + resistance);
+        }
+        else if (wire2ChargeTouch == true)
+        {
+            Transform wireEnd1Transform = transform.Find("wire end 1");
+            wireEnd1Script.resistance = resistance;
+            wireEnd1Transform.tag = "resistor output";
+            Debug.Log("wire end 1 is now resistor with " + resistance);
+        }
+
+
+
+
+    }
+}

--- a/resistor_movement_script.cs
+++ b/resistor_movement_script.cs
@@ -1,0 +1,50 @@
+using System.Collections;
+using System.Collections.Generic;
+using Unity.VisualScripting;
+using UnityEngine;
+
+public class resistor_movement_script : MonoBehaviour
+{
+    static resistor_movement_script lastClick;
+    bool onMouseClick = false;
+    void Update()
+    {
+        if (onMouseClick && lastClick == this)
+        {
+            HandleMovement();
+        }
+
+    }
+    private void OnMouseDown()
+    {
+        onMouseClick = true;
+        lastClick = this;
+    }
+    private void HandleMovement()
+    {
+        int speed = 4;
+        float y_move = 0;
+        float x_move = 0;
+        if (Input.GetKey(KeyCode.UpArrow))
+        {
+            y_move = 1.0f;
+        }
+        if (Input.GetKey(KeyCode.DownArrow))
+        {
+            y_move = -1.0f;
+        }
+        if (Input.GetKey(KeyCode.RightArrow))
+        {
+            x_move = 1.0f;
+        }
+        if (Input.GetKey(KeyCode.LeftArrow))
+        {
+            x_move = -1.0f;
+        }
+        Vector3 direction = new Vector3(x_move, y_move, 0).normalized;
+
+        transform.position += direction * Time.deltaTime * speed;
+
+    }
+}
+

--- a/source_bar_script.cs
+++ b/source_bar_script.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using Unity.PlasticSCM.Editor.WebApi;
+using UnityEngine;
+
+public class source_bar_script : MonoBehaviour
+{
+    
+    public float voltage = 5;
+    public float totalResistance = 0;
+    public float current = 0;
+
+
+        public void RecalculateCurrent(float totalResistance)
+    {
+        //Debug.Log("total resitance within function is "+ totalResistance);
+        current = voltage / totalResistance;
+        //Debug.Log("calculated current is " + current);
+    }
+}

--- a/wire_end1_script.cs
+++ b/wire_end1_script.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class wire_end1_script : MonoBehaviour
+{
+    public float contactVoltage = 0;
+    // we will be taking information from an outside script of a game object
+    // with type "breaboard_row_script"
+
+    public breaboard_row_script breadboardRowScript; // could be gotten rid of, dont need variable to hold script data
+    public source_bar_script sourceBarScript;          // ""
+    public bool sourceTouch = false;
+    public bool chargeTouch = false;
+    public float outputVoltage { get;  set; } = 0;
+    public float resistance { get; set; } = 0;
+
+    //check to see if wire is touching anything
+    public void OnTriggerEnter2D(Collider2D collision)
+    {
+        //decalre what it is touching
+        string objectName = collision.gameObject.name;
+       // Debug.Log("wire end 1 Touched " + objectName);
+
+        //check the script of the object being touched to see if it is a breaboard row or a source bar
+        if (collision.gameObject.CompareTag("source"))
+        {
+            contactVoltage = collision.gameObject.GetComponent<source_bar_script>().voltage;
+            //contactVoltage = sourceBarScript.voltage;
+            Debug.Log("wire end 1 touching source of " + contactVoltage + "volts");
+            sourceTouch = true;
+        }
+        if (collision.gameObject.CompareTag("charged board row"))
+        {
+            breadboardRowScript = collision.gameObject.GetComponent<breaboard_row_script>();
+            contactVoltage = breadboardRowScript.rowVoltage;
+            Debug.Log("wire end 1 touching bar with " + contactVoltage + "volts");
+            chargeTouch = true;
+        }
+
+        
+    }
+    public void OnTriggerExit2D(Collider2D collision)
+    {
+        contactVoltage = 0;
+        sourceTouch = false;
+    }
+}

--- a/wire_end2_script.cs
+++ b/wire_end2_script.cs
@@ -1,0 +1,46 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class wire_end2_script : MonoBehaviour
+{
+    public float contactVoltage = 0;
+    // we will be taking information from an outside script of a game object
+    // with type "breaboard_row_script"
+
+    public breaboard_row_script breadboardRowScript;
+    public source_bar_script sourceBarScript;
+    public bool sourceTouch = false;
+    public bool chargeTouch = false;
+    public float outputVoltage { get; set; } = 0;
+    public float resistance { get; set; } = 0;
+
+
+    //check to see if wire is touching anything
+    public void OnTriggerEnter2D(Collider2D collision)
+    {
+        //decalre what it is touching
+        string objectName = collision.gameObject.name;
+        //Debug.Log("wire end 2 Touched " + objectName);
+
+        //check the script of the object being touched to see if it is a breaboard row or a source bar
+        if (collision.gameObject.CompareTag("source"))
+        {
+            contactVoltage = collision.gameObject.GetComponent<source_bar_script>().voltage;
+            Debug.Log("wire end 2 touching source of " + contactVoltage + "volts");
+            sourceTouch = true;
+        }
+        if (collision.gameObject.CompareTag("charged board row"))
+        {
+            contactVoltage = collision.gameObject.GetComponent<breaboard_row_script>().rowVoltage;
+            Debug.Log("wire end 2 touching bar with " + contactVoltage + "volts");
+            chargeTouch = true;
+        }
+    }
+    public void OnTriggerExit2D(Collider2D collision)
+    {
+        contactVoltage = 0;
+        sourceTouch = false;
+        chargeTouch = false;
+    }
+}

--- a/wire_logic_script.cs
+++ b/wire_logic_script.cs
@@ -1,0 +1,74 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class wire_logic_script : MonoBehaviour
+{
+    public wire_end1_script wireEnd1Script;
+    public wire_end2_script wireEnd2Script;
+    void Update()
+    {
+        wire_logic();
+    }
+
+    bool wire1SourceTouch = false;
+    bool wire2SourceTouch = false;
+    bool wire1ChargeTouch = false;
+    bool wire2ChargeTouch = false;
+    
+
+    void wire_logic()
+    {
+        // check if either end is touching a source or a charge
+        wireEnd1Script = GetComponentInChildren<wire_end1_script>();
+        wire1SourceTouch = wireEnd1Script.sourceTouch;
+        wireEnd2Script = GetComponentInChildren<wire_end2_script>();
+        wire2SourceTouch = wireEnd2Script.sourceTouch;
+
+        wireEnd1Script = GetComponentInChildren<wire_end1_script>();
+        wire1ChargeTouch = wireEnd1Script.chargeTouch;
+        wireEnd2Script = GetComponentInChildren<wire_end2_script>();
+        wire2ChargeTouch = wireEnd2Script.chargeTouch;
+
+
+        float output;
+ // if 1 is touching a source, then 2 is sending the source i.e. is output
+        
+        if (wire1SourceTouch == true)   
+        {
+            Transform wireEnd2Transform = transform.Find("wire end 2");
+            wireEnd2Transform.tag = "output";
+            output = wireEnd1Script.contactVoltage;
+            wireEnd2Script.outputVoltage = output;
+            Debug.Log("wire end 2 now output with " + output);
+        }
+        //vice versa
+        else if (wire2SourceTouch == true)
+        {
+            Transform wireEnd1Transform = transform.Find("wire end 1");
+            wireEnd1Transform.tag = "output";
+            wireEnd1Script.outputVoltage = wireEnd2Script.contactVoltage;
+            Debug.Log("wire end 1 now output");
+        }
+
+        // if wire 1 touches active non source bar, carry signal to be output of 2
+        else if (wire1ChargeTouch == true)
+        {
+            Transform wireEnd2Transform = transform.Find("wire end 2");
+            wireEnd2Script.outputVoltage = wireEnd1Script.contactVoltage;
+            wireEnd2Transform.tag = "output";
+            Debug.Log("wire end 2 is now output");
+        }
+        else if (wire2ChargeTouch == true)
+        {
+            Transform wireEnd1Transform = transform.Find("wire end 1");
+            wireEnd1Script.outputVoltage = wireEnd1Script.contactVoltage;
+            wireEnd1Transform.tag = "output";
+            Debug.Log("wire end 1 is now output");
+        }
+        
+
+
+
+    }
+}

--- a/wire_script.cs
+++ b/wire_script.cs
@@ -1,0 +1,49 @@
+using System.Collections;
+using System.Collections.Generic;
+using Unity.VisualScripting;
+using UnityEngine;
+
+public class wire_script : MonoBehaviour
+{   static wire_script lastClick; 
+    bool onMouseClick = false;
+    void Update()
+    {
+        if (onMouseClick && lastClick== this)
+        {
+            HandleMovement();
+        }
+
+    }
+    private void OnMouseDown()
+    {   
+        onMouseClick = true;
+        lastClick = this;
+    }
+    private void HandleMovement()
+    {
+        int speed = 4;
+        float y_move = 0;
+        float x_move = 0;
+        if (Input.GetKey(KeyCode.UpArrow))
+        {
+            y_move = 1.0f;
+        }
+        if (Input.GetKey(KeyCode.DownArrow))
+        {
+            y_move = -1.0f;
+        }
+        if (Input.GetKey(KeyCode.RightArrow))
+        {
+            x_move = 1.0f;
+        }
+        if (Input.GetKey(KeyCode.LeftArrow))
+        {
+            x_move = -1.0f;
+        }
+        Vector3 direction = new Vector3(x_move, y_move, 0).normalized;
+
+        transform.position += direction * Time.deltaTime * speed;
+
+    }
+}
+


### PR DESCRIPTION
Scripts are classified as assets and do not create an entire entity within unity, but are instead small portions of entities and do not include the collision boxes or the parent child hierarchy, these portions of the entities must be created within unity and as far as I know cannot be file shared the same way the scripts can be.

Resistor and wire Logic scripts are attached to the parent entity along with the movement scripts, wire end scripts are attached to separate child entities within the parent (wire end scripts are shared by both wire, and resistor ends), breadboard row and source bar scripts are attached to children within a larger breadboard parent, but the parent itself has no scripts